### PR TITLE
Fix load_project search result handling

### DIFF
--- a/UI/event_handling.py
+++ b/UI/event_handling.py
@@ -157,11 +157,12 @@ def load_project():
         messagebox. showerror( "Lỗi", "Vui lòng chọn một ID dự án!")
         return
 # # Tìm dự án
-    success, row, message = search_projects( project_id)
+    success, results, message = search_projects( project_id)
     if not success:
         messagebox. showerror( "Lỗi", message)
         return
-# # Điền thông tin
+# # Điền thông tin từ kết quả đầu tiên
+    row = results[0]
     update_name_entry. delete( 0, tk.END)
     update_name_entry. insert( 0, row[ 1])
     update_desc_entry. delete( 0, tk.END)


### PR DESCRIPTION
## Summary
- use `search_projects(project_id)` in `load_project`
- handle returned list by taking first row

## Testing
- `python -m py_compile UI/event_handling.py Business_function_CRUD/Find_project.py Business_function_CRUD/Update_project.py`

------
https://chatgpt.com/codex/tasks/task_e_68401f37c430832d9252c6d6b8ae4e18